### PR TITLE
Added mod fluids registration to JEI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ forge_gradle_version=[6.0,6.2)
 
 
 # Dependency parameters 
-jei_version=15.2.0.26
+jei_version=15.19.0.85
 cursegradle_version=1.4.0
 mekanism_version = 1.19.2-10.3.7.476
 

--- a/src/main/java/dynamicelectricity/compatability/jei/DynamicElectricityJEIPlugin.java
+++ b/src/main/java/dynamicelectricity/compatability/jei/DynamicElectricityJEIPlugin.java
@@ -1,12 +1,41 @@
 package dynamicelectricity.compatability.jei;
 
 import dynamicelectricity.References;
+import dynamicelectricity.registry.DynamicElectricityFluids;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.forge.ForgeTypes;
+import mezz.jei.api.registration.IExtraIngredientRegistration;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 @JeiPlugin
-public class DynamicElectricityJEIPlugin implements IModPlugin {
+public class DynamicElectricityJEIPlugin implements IModPlugin
+{
+
+	private static FluidStack makeFluidStack(RegistryObject<Fluid> fluid)
+	{
+		FluidStack fluidStack;
+		fluidStack = new FluidStack(fluid.get(), 1000);
+		return fluidStack;
+	}
+
+	@Override
+	public void registerExtraIngredients(IExtraIngredientRegistration registration)
+	{
+		Collection<RegistryObject<Fluid>> fluids = DynamicElectricityFluids.FLUIDS.getEntries();
+		Collection<FluidStack> modFluids = new ArrayList<>();
+		for (RegistryObject<Fluid> fluid : fluids)
+		{
+			modFluids.add(makeFluidStack(fluid));
+		}
+		registration.addExtraIngredients(ForgeTypes.FLUID_STACK, modFluids);
+	}
 
 	@Override
 	public ResourceLocation getPluginUid() {


### PR DESCRIPTION
Added fluid registration to JEI so you can see how it crafted and supply lubricant through Applied Energistics ME system (Also use it in crafting pattern, import/export/storage buses)

Same feature pull request is also pending to original Electrodynamics mod repository.
In both I updated JEI version to newer.